### PR TITLE
Fix parsing of Unix timestamps from results

### DIFF
--- a/webui/sg-view/components/SGCommits.vue
+++ b/webui/sg-view/components/SGCommits.vue
@@ -168,7 +168,7 @@
                 let name = `${benchmark}-${runtime}`;
                 points[name] = points[name] || {name: name, data: {}};
                 const slowdown = run.results[benchmark][runtime].mean / run.results[benchmark][run.meta.reference_runtime].mean;
-                const date = new Date(run.meta.timestamp).toISOString();
+                const date = run.meta.timestamp.toISOString();
                 points[name].data[date] = slowdown
               }
             }
@@ -181,7 +181,7 @@
             let points = {name: runtime, data: {}};
             for (const run of this.filtered_items.filter(r => r.runtime === runtime)) {
               const slowdown = calculate_average_slowdown_ratio(runtime, run.meta.reference_runtime, run);
-              const date = new Date(run.meta.timestamp).toISOString();
+              const date = run.meta.timestamp.toISOString();
               points.data[date] = slowdown
             }
             chartdata.push(points);

--- a/webui/sg-view/js/retrieval.js
+++ b/webui/sg-view/js/retrieval.js
@@ -16,7 +16,7 @@ export function calculate_geometric_mean(numbers) {
  * @return {number} the average slowdown, e.g. the target is 1.7x slower than the reference
  */
 export function calculate_average_slowdown_ratio(target, reference, run) {
-  console.debug(`Calculating average slodown ratio of ${target} to ${reference}`, run);
+  console.debug(`Calculating average slowdown ratio of ${target} to ${reference}`, run);
   const target_means = [];
   const reference_means = [];
   for (const benchmark of Object.keys(run.results)) {
@@ -93,4 +93,15 @@ export function extract_target_runtime(target, run) {
   } else {
     return null;
   }
+}
+
+/**
+ * Replace the metadata Unix timestamps in history with JS Date objects for easier processing; note that this modifies
+ * the input history.
+ * @param history - the output of sg-history, see `[top-level]/test/fixtures/history-output.json`
+ * @return {object} the modified history (warning: this is the same reference as the input parameter, not a clone)
+ */
+export function fixup_unix_timestamps(history) {
+  Object.values(history).map(r => r.meta.timestamp = new Date(r.meta.timestamp * 1000));
+  return history;
 }

--- a/webui/sg-view/pages/index.vue
+++ b/webui/sg-view/pages/index.vue
@@ -12,12 +12,12 @@
 <script>
   import SGCommits from "~/components/SGCommits.vue";
   import axios from "axios";
-  import {extract_benchmarks, extract_runtimes, extract_suites} from "../js/retrieval";
+  import {extract_benchmarks, extract_runtimes, extract_suites, fixup_unix_timestamps} from "../js/retrieval";
 
   let host_history = process.env.HISTORY_URL;
   if (!host_history) {
     if (process.client) {
-      host_history = "http://"+window.location.hostname+":8001/history";
+      host_history = "http://" + window.location.hostname + ":8001/history";
     } else {
       host_history = "http://localhost:8001/history";
     }
@@ -32,15 +32,15 @@
         .get(host_history)
         .then(response => {
           this.loading = false;
-          this.history = response.data.history;
-          this.benchmarks = extract_benchmarks(response.data.history);
-          this.suites = extract_suites(response.data.history);
-          this.runtimes = extract_runtimes(response.data.history);
+          this.history = fixup_unix_timestamps(response.data.history);
+          this.benchmarks = extract_benchmarks(this.history);
+          this.suites = extract_suites(this.history);
+          this.runtimes = extract_runtimes(this.history);
         })
         .catch(e => {
           this.loading = false;
-          this.errors.push(e);
           console.error(e);
+          this.errors.push(e);
         });
     },
     data() {
@@ -50,6 +50,7 @@
         runtimes: [],
         suites: [],
         benchmarks: [],
+        errors: [],
       };
     }
   };


### PR DESCRIPTION
Previously, the Unix timestamp in the results metadata was not parsed correctly by the UI. Now, upon receiving the results, the UI will replace each run's timestamp with a JS Date object. This change also includes some formatting fixes.