### PR TITLE
Re-add Nuxt configuration for passing HISTORY_URL to client

### DIFF
--- a/webui/sg-view/nuxt.config.js
+++ b/webui/sg-view/nuxt.config.js
@@ -16,11 +16,11 @@ module.exports = {
   head: {
     title: "sg-view",
     meta: [
-      { charset: "utf-8" },
-      { name: "viewport", content: "width=device-width, initial-scale=1" },
-      { hid: "description", name: "description", content: "SightGlass viewer" }
+      {charset: "utf-8"},
+      {name: "viewport", content: "width=device-width, initial-scale=1"},
+      {hid: "description", name: "description", content: "SightGlass viewer"}
     ],
-    link: [{ rel: "icon", type: "image/x-icon", href: "/favicon.ico" }]
+    link: [{rel: "icon", type: "image/x-icon", href: "/favicon.ico"}]
   },
 
   css: [
@@ -33,7 +33,7 @@ module.exports = {
   /*
   ** Customize the progress bar color
   */
-  loading: { color: "#3B8070" },
+  loading: {color: "#3B8070"},
   /*
   ** Build configuration
   */
@@ -42,7 +42,7 @@ module.exports = {
     /*
     ** Run ESLint on save
     */
-    extend(config, { isDev, isClient }) {
+    extend(config, {isDev, isClient}) {
       if (isDev && isClient) {
         config.module.rules.push({
           enforce: "pre",
@@ -53,4 +53,12 @@ module.exports = {
       }
     }
   },
+
+  /*
+  ** Pass the HISTORY_URL from the server environment to the client for accessing different sg-history servers; though
+  ** this line may seem redundant, it ensures that the client receives the server-defined variable.
+   */
+  env: {
+    HISTORY_URL: process.env.HISTORY_URL || 'http://localhost:8001',
+  }
 };


### PR DESCRIPTION
Apparently my comment https://github.com/CraneStation/sightglass/pull/12#discussion_r337107018 was incorrect; we do need this block in order to point the client to different servers. The rest of the changes are from auto-formatting.